### PR TITLE
Make customization adhere to schema and fix seed

### DIFF
--- a/random_palettes.py
+++ b/random_palettes.py
@@ -35,7 +35,7 @@ class PaletteSettings(object):
         hue_max: int,
         color_space: ColorSpace
     ):
-        self.seed = seed,
+        self.seed = seed
         self.pal_types = pal_types
         self.hue_min = hue_min
         self.hue_max = hue_max
@@ -43,10 +43,11 @@ class PaletteSettings(object):
 
     @classmethod
     def from_json(cls, data: Any) -> "PaletteSettings":
-        seed = data["Seed"]
+        seed = data.get("Seed", random.randint(0, 2**31))
+        random.seed(seed)
         pal_types = [cls.TYPE_ENUMS[t] for t in data["Randomize"]]
-        hue_min = data["HueMin"]
-        hue_max = data["HueMax"]
+        hue_min = data.get("HueMin", random.randint(0, 180))
+        hue_max = data.get("HueMax", random.randint(hue_min, 180))
         color_space = ColorSpace[data["ColorSpace"]]
         return cls(seed, pal_types, hue_min, hue_max, color_space)
 


### PR DESCRIPTION
This PR does two things.
- A small typo lead to the `Seed` being interpreted as a tuple instead of as an int.
- It makes the customization options adhere to the schema:
  Currently the schema says only "Randomize" is required, but the current code crashes if the other ones are not provided. This PR fixes it, by using default values:
  If the seed is not provided, it will generate a random seed. If the Hue values are not provided, it will generate random hue values from 0-180 based on the seed.