### PR TITLE
Add CI

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,0 +1,116 @@
+name: Python Package
+
+on:
+  push:
+    branches:
+     - main
+    tags:
+      - '*'
+
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Build MFR and Python Wheel
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: 'recursive'
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.7"
+
+      - name: Install Python packages
+        run: python -m pip install --upgrade pip build
+
+      - name: build
+        # Ideally, we'd have PYTHONWARNINGS=error here, but
+        # https://github.com/pypa/pip/issues/12243 is causing issues.
+        run: python -m build
+
+      - name: Store the packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist
+
+  test:
+    needs:
+      - build
+
+    runs-on: ubuntu-latest
+    name: Test Python ${{ matrix.python.version }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python:
+          - {version: '3.7'}
+          - {version: '3.8'}
+          - {version: '3.9'}
+          - {version: '3.10'}
+          - {version: '3.11'}
+          - {version: '3.12'}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: remove code outside of wheel
+        run: rm -rf src
+        shell: bash
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python.version }}
+
+      - name: Download all the dists
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Install Python packages
+        run: python -m pip install --upgrade pip
+
+      - name: install built wheel
+        run: python -m pip install "$(ls dist/*.whl)[test]"
+        shell: bash
+
+      # Repo currently does not have any tests
+      # - name: run pytest
+      #   run: python -m pytest --cov
+
+      - name: codecov
+        uses: codecov/codecov-action@v4
+
+  pypi:
+    runs-on: 'ubuntu-latest'
+    needs:
+      - test
+
+    permissions:
+      id-token: write
+      
+    steps:
+      - name: Download all the dists
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+      
+      # Publish to PyPI on tag push. Commented out until out of early alpha.
+      # When this gets commented out, an access key needs to be added to the repo.
+      # - name: Publish 📦 to PyPI
+      #   if: ${{ startsWith(github.ref, 'refs/tags/') }}
+      #   uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
This adds Python CI that does basically 3 things:
Basic Build:
- On every new push on main, or for PRs targeting main, a new build with python 3.7 will be uploaded as an artifact

Test:
- After the basic build, the artifact will be downloaded, and with that module testing will be done on python versions 3.7-3.12. As this project currently doesn't have any unit tests, it doesn't do that much.

Release:
- If a **tag** has been pushed, and testing has been done, then it will push the module to pypi (basically the python equivalent of nuget.org). As this project is currently in very early alpha, it is commented out.