### PR TITLE
Update TankIncrement to be less strict

### DIFF
--- a/src/mfr_patcher/data/schema.json
+++ b/src/mfr_patcher/data/schema.json
@@ -96,7 +96,7 @@
             "properties": {
                 "MissileTank": {
                     "type": "integer",
-                    "minimum": -0,
+                    "minimum": -1000,
                     "maximum": 1000
                 },
                 "EnergyTank": {

--- a/src/mfr_patcher/data/schema.json
+++ b/src/mfr_patcher/data/schema.json
@@ -95,12 +95,12 @@
             "type": "object",
             "properties": {
                 "MissileTank": {
+                    "$ref": "#/$defs/TankIncrementNumber"
+                },
+                "EnergyTank": {
                     "type": "integer",
                     "minimum": 0,
                     "maximum": 999
-                },
-                "EnergyTank": {
-                    "$ref": "#/$defs/TankIncrementNumber"
                 },
                 "PowerBombTank": {
                      "$ref": "#/$defs/TankIncrementNumber"

--- a/src/mfr_patcher/data/schema.json
+++ b/src/mfr_patcher/data/schema.json
@@ -95,15 +95,19 @@
             "type": "object",
             "properties": {
                 "MissileTank": {
-                    "$ref": "#/$defs/TankIncrementNumber"
+                    "type": "integer",
+                    "minimum": -0,
+                    "maximum": 1000
                 },
                 "EnergyTank": {
                     "type": "integer",
-                    "minimum": 0,
-                    "maximum": 999
+                    "minimum": -2100,
+                    "maximum": 2100
                 },
                 "PowerBombTank": {
-                     "$ref": "#/$defs/TankIncrementNumber"
+                     "type": "integer",
+                    "minimum": -100,
+                    "maximum": 100
                 }
             },
             "required": ["MissileTank", "EnergyTank", "PowerBombTank"]
@@ -144,11 +148,6 @@
             "type": "integer",
             "minimum": 0,
             "maximum": 255
-        },
-        "TankIncrementNumber": {
-            "type": "integer",
-            "minimum": -99,
-            "maximum": 99
         },
         "Seed": {
             "type": "integer",

--- a/src/mfr_patcher/data/schema.json
+++ b/src/mfr_patcher/data/schema.json
@@ -95,19 +95,13 @@
             "type": "object",
             "properties": {
                 "MissileTank": {
-                    "type": "integer",
-                    "minimum": 1,
-                    "maximum": 5
+                    "$ref": "#/$defs/TankIncrementNumber"
                 },
                 "EnergyTank": {
-                    "type": "integer",
-                    "minimum": 1,
-                    "maximum": 100
+                    "$ref": "#/$defs/TankIncrementNumber"
                 },
                 "PowerBombTank": {
-                    "type": "integer",
-                    "minimum": 1,
-                    "maximum": 2
+                     "$ref": "#/$defs/TankIncrementNumber"
                 }
             },
             "required": ["MissileTank", "EnergyTank", "PowerBombTank"]
@@ -148,6 +142,11 @@
             "type": "integer",
             "minimum": 0,
             "maximum": 255
+        },
+        "TankIncrementNumber": {
+            "type": "integer",
+            "minimum": -99,
+            "maximum": 99
         },
         "Seed": {
             "type": "integer",

--- a/src/mfr_patcher/data/schema.json
+++ b/src/mfr_patcher/data/schema.json
@@ -95,7 +95,9 @@
             "type": "object",
             "properties": {
                 "MissileTank": {
-                    "$ref": "#/$defs/TankIncrementNumber"
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 999
                 },
                 "EnergyTank": {
                     "$ref": "#/$defs/TankIncrementNumber"

--- a/src/mfr_patcher/data/schema.json
+++ b/src/mfr_patcher/data/schema.json
@@ -105,7 +105,7 @@
                     "maximum": 2100
                 },
                 "PowerBombTank": {
-                     "type": "integer",
+                    "type": "integer",
                     "minimum": -100,
                     "maximum": 100
                 }


### PR DESCRIPTION
Anty mentioned that theoretically the patcher supports this and even higher value. Altho the game has a few issues on really really high values, so I just capped this to here. Should theoretically suffice for every sensible usecase.